### PR TITLE
fix: log Resource API actions

### DIFF
--- a/src/Resource.js
+++ b/src/Resource.js
@@ -19,11 +19,11 @@ export class Resource extends EventEmitter {
    * @param {object} [payload] - Payload instance to use, defaults to base Payload instance
    */
   constructor (id, path, $api, payload = null) {
-    super()
-
     if (!id) { throw new Error('[Resource] ID not provided') }
     if (!path) { throw new Error('[Resource] path not provided') }
     if (!$api) { throw new Error('[Resource] API instance not provided') }
+
+    super()
 
     /**
      * Shareable payload for this resource.

--- a/src/Resource.js
+++ b/src/Resource.js
@@ -64,7 +64,7 @@ export class Resource extends EventEmitter {
      * Namespace. Can be used as a readable global identifier.
      * @type {string}
      */
-    this.namespace = `Resource<${this.path}>#${this.id}`
+    this.namespace = `Resource:/${this.endpoint}`
   }
 
   /**

--- a/src/Runtime.js
+++ b/src/Runtime.js
@@ -2,6 +2,8 @@
 
 'use strict'
 
+import EventEmitter from 'eventemitter3'
+
 import $logger from '../config/logger.js'
 
 /**
@@ -9,7 +11,7 @@ import $logger from '../config/logger.js'
  *
  * Base runtime class.
  */
-export class Runtime {
+export class Runtime extends EventEmitter {
   /**
    * @param {ResourceType} resource - Resource this Runtime is attached to.
    * @param {string} [namespace] - Runtime namespace, defined by subclasses.
@@ -17,12 +19,16 @@ export class Runtime {
   constructor (resource, namespace) {
     if (!resource?._isResource) { throw new Error('[Runtime] resource argument is not a Resource instance') }
 
+    super()
+
     /**
      * Resource this Runtime is attached to.
      * Subclasses can determine the Resource subclass by using `extends`.
      * @type {ResourceType}
      */
     this.resource = resource
+    resource.on('downloaded', this.onResourceDownload, this)
+    resource.on('patched', this.onResourcePatch, this)
 
     /**
      * Namespace. Can be used as a readable global identifier.
@@ -32,7 +38,7 @@ export class Runtime {
 
     /**
      * Utility flag for performance.
-     * @constant
+     * @readonly
      * @type {boolean}
      */
     this._isRuntime = true
@@ -43,6 +49,26 @@ export class Runtime {
    * @return {number}
    */
   get id () { return this.resource?.id }
+
+  /**
+   * Called when the resource is downloaded.
+   * @param {ResourceType} resource
+   * @param {object} _data - Downloaded data
+   * @param {number} duration - Duration in milliseconds.
+   */
+  onResourceDownload (resource, _data, duration) {
+    resource.log('info', 'Downloaded in', duration, 'ms')
+  }
+
+  /**
+   * Called when the resource is patched.
+   * @param {ResourceType} resource
+   * @param {object} _data - Object returned from the API.
+   * @param {number} duration - Duration in milliseconds.
+   */
+  onResourcePatch (resource, _data, duration) {
+    resource.log('info', 'Patched in', duration, 'ms')
+  }
 
   /**
    * @param {string} level

--- a/src/Runtime.js
+++ b/src/Runtime.js
@@ -57,7 +57,7 @@ export class Runtime extends EventEmitter {
    * @param {number} duration - Duration in milliseconds.
    */
   onResourceDownload (resource, _data, duration) {
-    resource.log('info', 'Downloaded in', duration, 'ms')
+    resource.log('info', '> GET in', duration, 'ms')
   }
 
   /**
@@ -67,7 +67,7 @@ export class Runtime extends EventEmitter {
    * @param {number} duration - Duration in milliseconds.
    */
   onResourcePatch (resource, _data, duration) {
-    resource.log('info', 'Patched in', duration, 'ms')
+    resource.log('info', '> PATCH in', duration, 'ms')
   }
 
   /**


### PR DESCRIPTION
Resource emits `download` and `patch`; the Runtime is responsible for logging those events.

- [x] Runtime should be an EventEmitter
- [x] listen to Resource download and patch and log them